### PR TITLE
add the option to run the server offline

### DIFF
--- a/apis/uuid/uuids.go
+++ b/apis/uuid/uuids.go
@@ -3,7 +3,7 @@ package uuid
 import (
 	"encoding/binary"
 
-	"github.com/satori/go.uuid"
+	uuid "github.com/satori/go.uuid"
 )
 
 type UUID = uuid.UUID
@@ -17,8 +17,8 @@ func NewUUID() UUID {
 	return gen
 }
 
-func TextToUUID(text string) (data UUID, err error) {
-	return uuid.FromString(text)
+func TextToUUID(text string) (data UUID) {
+	return uuid.FromStringOrNil(text)
 }
 
 func BitsToUUID(msb, lsb int64) (data UUID, err error) {

--- a/impl/conf/config.go
+++ b/impl/conf/config.go
@@ -5,10 +5,12 @@ var DefaultServerConfig = ServerConfig{
 		Host: "0.0.0.0",
 		Port: 25565,
 	},
+	Offline: false,
 }
 
 type ServerConfig struct {
 	Network Network
+	Offline bool `toml:"offline"`
 }
 
 type Network struct {

--- a/impl/prot/packets.go
+++ b/impl/prot/packets.go
@@ -19,7 +19,7 @@ type packets struct {
 	quit chan base.PlayerAndConnection
 }
 
-func NewPackets(tasking *task.Tasking, join chan base.PlayerAndConnection, quit chan base.PlayerAndConnection) base.Packets {
+func NewPackets(tasking *task.Tasking, join chan base.PlayerAndConnection, quit chan base.PlayerAndConnection, offline bool) base.Packets {
 	packets := &packets{
 		Watcher: util.NewWatcher(),
 
@@ -29,7 +29,7 @@ func NewPackets(tasking *task.Tasking, join chan base.PlayerAndConnection, quit 
 
 	mode.HandleState0(packets)
 	mode.HandleState1(packets)
-	mode.HandleState2(packets, join)
+	mode.HandleState2(packets, join, offline)
 	mode.HandleState3(packets, packets.logger, tasking, join, quit)
 
 	return packets

--- a/impl/server.go
+++ b/impl/server.go
@@ -60,7 +60,7 @@ func NewServer(conf conf.ServerConfig) apis.Server {
 	join := make(chan impl_base.PlayerAndConnection)
 	quit := make(chan impl_base.PlayerAndConnection)
 
-	packets := prot.NewPackets(tasking, join, quit)
+	packets := prot.NewPackets(tasking, join, quit, conf.Offline)
 	network := conn.NewNetwork(conf.Network.Host, conf.Network.Port, packets, message, join, quit)
 
 	command := cmds.NewCommandManager()

--- a/main.go
+++ b/main.go
@@ -25,6 +25,10 @@ func mergeWithFlags(c conf.ServerConfig) conf.ServerConfig {
 		conf.DefaultServerConfig.Network.Port,
 		"the port this server will bind to")
 
+	offline := flag.Bool("offline",
+		conf.DefaultServerConfig.Offline,
+		"do not authenticate against Mojang's session server")
+
 	flag.Parse()
 
 	if *host != conf.DefaultServerConfig.Network.Host {
@@ -33,6 +37,10 @@ func mergeWithFlags(c conf.ServerConfig) conf.ServerConfig {
 
 	if *port != conf.DefaultServerConfig.Network.Port {
 		c.Network.Port = *port
+	}
+
+	if *offline != conf.DefaultServerConfig.Offline {
+		c.Offline = *offline
 	}
 
 	return c


### PR DESCRIPTION
This PR adds the option to run the server in offline mode, i.e. no Internet connection is required to connect to the server as authentication against Mojang's session server is disabled.

According to https://wiki.vg/Protocol_FAQ#Offline_mode,

> If the server is in offline mode, it will not send the Encryption Request packet, and likewise, the client should not send Encryption Response. In this case, encryption is never enabled, and no authentication is performed.

So, I added a condition to the Login Start packet watcher to just add the player and return early before any sort of authentication happens. Otherwise, we get the following error:

<img width="872" alt="image" src="https://user-images.githubusercontent.com/9457739/77881546-3a929080-722d-11ea-99de-f4ff7d986f3c.png">

Further, sometimes using cracked clients is much easier for iteration and testing. In this case, the error is failing to parse the response from Mojang (since of course, it's a cracked client and failed the server's client-bound encryption request).

<img width="877" alt="image" src="https://user-images.githubusercontent.com/9457739/77881586-4da56080-722d-11ea-88ab-b31c1c1754e3.png">




